### PR TITLE
Misc improvements

### DIFF
--- a/leptos_workers/Cargo.toml
+++ b/leptos_workers/Cargo.toml
@@ -43,7 +43,7 @@ features = [
     "ErrorEvent",
     "HtmlElement",
     "HtmlInputElement",
-    "Location",
+    "Node",
     "MessageEvent",
     "Navigator",
     "Performance",

--- a/leptos_workers/src/lib.rs
+++ b/leptos_workers/src/lib.rs
@@ -235,7 +235,7 @@ pub use futures::stream::LocalBoxStream;
 #[doc(hidden)]
 pub use futures::stream::StreamExt;
 #[doc(hidden)]
-pub use wasm_bindgen::prelude::wasm_bindgen;
+pub use wasm_bindgen;
 
 extern crate alloc;
 extern crate core;

--- a/leptos_workers/src/plumbing/create_worker.rs
+++ b/leptos_workers/src/plumbing/create_worker.rs
@@ -6,8 +6,6 @@ use web_sys::{window, Blob, BlobPropertyBag, Url, Worker, WorkerOptions, WorkerT
 
 use crate::workers::WebWorker;
 
-use super::dedicated_worker;
-
 /// Describes failures related to worker creation.
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
@@ -110,9 +108,10 @@ fn find_js_wasm_urls() -> Result<(Url, Url), CreateWorkerError> {
     resolve_js_wasm_path(&js_path, &wasm_path)
 }
 
-pub fn create_worker<W: WebWorker>() -> Result<Worker, CreateWorkerError> {
+pub fn create_unifunctional_worker<W: WebWorker>() -> Result<Worker, CreateWorkerError> {
     let (js_url, wasm_url) = find_js_wasm_urls()?;
-    let module_def = dedicated_worker::web_module(&js_url.to_string(), &wasm_url.to_string());
+    let module_def =
+        super::unifunctional_worker::web_module(&js_url.to_string(), &wasm_url.to_string());
     create_worker_from_module(W::path(), &module_def)
 }
 

--- a/leptos_workers/src/plumbing/create_worker.rs
+++ b/leptos_workers/src/plumbing/create_worker.rs
@@ -128,29 +128,28 @@ pub fn create_worker_with_url<W: WebWorker>(
                 
                 async function load() {{
                     let mod = await init("{wasm_url}");
-                    let {{ init_workers, register_future_worker, register_stream_worker, register_callback_worker, register_channel_worker, memory }} = mod;
                     
                     let future_worker_fn = mod["WORKERS_FUTURE_" + self.name];
                     if (future_worker_fn) {{
-                        register_future_worker(mod["WORKERS_FUTURE_" + self.name]());
+                        mod["WORKERS_FUTURE_" + self.name]();
                     }}
                     
                     let stream_worker_fn = mod["WORKERS_STREAM_" + self.name];
                     if (stream_worker_fn) {{
-                        register_stream_worker(mod["WORKERS_STREAM_" + self.name]());
+                        mod["WORKERS_STREAM_" + self.name]();
                     }}
                     
                     let callback_worker_fn = mod["WORKERS_CALLBACK_" + self.name];
                     if (callback_worker_fn) {{
-                        register_callback_worker(mod["WORKERS_CALLBACK_" + self.name]());
+                        mod["WORKERS_CALLBACK_" + self.name]();
                     }}
                     
                     let channel_worker_fn = mod["WORKERS_CHANNEL_" + self.name];
                     if (channel_worker_fn) {{
-                        register_channel_worker(mod["WORKERS_CHANNEL_" + self.name]());
+                        mod["WORKERS_CHANNEL_" + self.name]();
                     }}
                     
-                    init_workers();
+                    mod.init_workers();
                 }}
                 load();
             "#

--- a/leptos_workers/src/plumbing/mod.rs
+++ b/leptos_workers/src/plumbing/mod.rs
@@ -1,7 +1,6 @@
 mod create_worker;
 pub use create_worker::*;
-mod init_workers;
-#[allow(unused_imports)]
-pub use init_workers::*;
 mod worker_handle;
 pub use worker_handle::*;
+
+mod dedicated_worker;

--- a/leptos_workers/src/plumbing/mod.rs
+++ b/leptos_workers/src/plumbing/mod.rs
@@ -3,4 +3,4 @@ pub use create_worker::*;
 mod worker_handle;
 pub use worker_handle::*;
 
-mod dedicated_worker;
+mod unifunctional_worker;

--- a/leptos_workers/src/plumbing/unifunctional_worker.rs
+++ b/leptos_workers/src/plumbing/unifunctional_worker.rs
@@ -44,24 +44,16 @@ pub(crate) fn web_module(js_url: &JsString, wasm_url: &JsString) -> String {
             let mod = await init("{wasm_url}");
             
             let future_worker_fn = mod["WORKERS_FUTURE_" + self.name];
-            if (future_worker_fn) {{
-                mod["WORKERS_FUTURE_" + self.name]();
-            }}
+            if (future_worker_fn) {{ future_worker_fn(); }}
             
             let stream_worker_fn = mod["WORKERS_STREAM_" + self.name];
-            if (stream_worker_fn) {{
-                mod["WORKERS_STREAM_" + self.name]();
-            }}
+            if (stream_worker_fn) {{ stream_worker_fn(); }}
             
             let callback_worker_fn = mod["WORKERS_CALLBACK_" + self.name];
-            if (callback_worker_fn) {{
-                mod["WORKERS_CALLBACK_" + self.name]();
-            }}
+            if (callback_worker_fn) {{ callback_worker_fn(); }}
             
             let channel_worker_fn = mod["WORKERS_CHANNEL_" + self.name];
-            if (channel_worker_fn) {{
-                mod["WORKERS_CHANNEL_" + self.name]();
-            }}
+            if (channel_worker_fn) {{ channel_worker_fn(); }}
             
             mod.init_workers();
         }}

--- a/leptos_workers/src/plumbing/unifunctional_worker.rs
+++ b/leptos_workers/src/plumbing/unifunctional_worker.rs
@@ -41,7 +41,7 @@ pub(crate) fn web_module(js_url: &JsString, wasm_url: &JsString) -> String {
         }}
         
         async function load() {{
-            let mod = await init("{wasm_url}");
+            let mod = await init({{ module_or_path: "{wasm_url}" }});
             
             let future_worker_fn = mod["WORKERS_FUTURE_" + self.name];
             if (future_worker_fn) {{ future_worker_fn(); }}

--- a/leptos_workers/src/plumbing/unifunctional_worker.rs
+++ b/leptos_workers/src/plumbing/unifunctional_worker.rs
@@ -1,4 +1,4 @@
-//! A dedicated web-worker handles a specific type of worker function and is started on demand.
+//! A uni-functional web-worker handles a specific type of worker function and is started on demand.
 use crate::messages::WorkerMsg;
 use crate::messages::WorkerMsgType;
 use crate::workers::CALLBACK_WORKER_FN;

--- a/leptos_workers/src/plumbing/worker_handle.rs
+++ b/leptos_workers/src/plumbing/worker_handle.rs
@@ -1,5 +1,5 @@
 use crate::messages::{WorkerMsg, WorkerMsgType};
-use crate::plumbing::{create_worker, CreateWorkerError};
+use crate::plumbing::{create_unifunctional_worker, CreateWorkerError};
 use crate::workers::CallbackWorker;
 use crate::workers::ChannelWorker;
 use crate::workers::FutureWorker;
@@ -24,7 +24,7 @@ pub struct WorkerHandle<W: WebWorker> {
 impl<W: WebWorker> WorkerHandle<W> {
     pub(crate) fn new() -> Result<Self, CreateWorkerError> {
         Ok(Self {
-            worker: create_worker::<W>()?,
+            worker: create_unifunctional_worker::<W>()?,
             _phantom: PhantomData,
         })
     }

--- a/leptos_workers_macro/src/v2/analyze.rs
+++ b/leptos_workers_macro/src/v2/analyze.rs
@@ -6,8 +6,8 @@ use proc_macro_error::abort;
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{
-    parse_quote, parse_quote_spanned, Attribute, FnArg, Generics, Pat, ReturnType, Signature, Stmt,
-    Type, Visibility,
+    parse_quote, parse_quote_spanned, Attribute, FnArg, Generics, Pat, Path, ReturnType, Signature,
+    Stmt, Type, Visibility,
 };
 
 pub fn analyze(ast: Ast) -> Model {
@@ -223,7 +223,7 @@ impl WorkerType {
         }
     }
 
-    pub fn worker_registration_fn(&self) -> Type {
+    pub fn worker_registration_fn(&self) -> Path {
         match self {
             WorkerType::Callback(_) => parse_quote!(register_callback_worker),
             WorkerType::Channel(_) => parse_quote!(register_channel_worker),

--- a/leptos_workers_macro/src/v2/analyze.rs
+++ b/leptos_workers_macro/src/v2/analyze.rs
@@ -223,12 +223,12 @@ impl WorkerType {
         }
     }
 
-    pub fn worker_fn_type(&self) -> Type {
+    pub fn worker_registration_fn(&self) -> Type {
         match self {
-            WorkerType::Callback(_) => parse_quote!(CallbackWorkerFn),
-            WorkerType::Channel(_) => parse_quote!(ChannelWorkerFn),
-            WorkerType::Future(_) => parse_quote!(FutureWorkerFn),
-            WorkerType::Stream(_) => parse_quote!(StreamWorkerFn),
+            WorkerType::Callback(_) => parse_quote!(register_callback_worker),
+            WorkerType::Channel(_) => parse_quote!(register_channel_worker),
+            WorkerType::Future(_) => parse_quote!(register_future_worker),
+            WorkerType::Stream(_) => parse_quote!(register_stream_worker),
         }
     }
 

--- a/leptos_workers_macro/src/v2/lower.rs
+++ b/leptos_workers_macro/src/v2/lower.rs
@@ -99,12 +99,12 @@ fn lower_wasm_bindgen_func(model: &Model) -> ItemFn {
     } = model;
     let prefix = worker_type.wasm_function_prefix();
     let func_name = format_ident!("{prefix}_{worker_name}");
-    let worker_fn_type = worker_type.worker_fn_type();
+    let worker_registration_fn = worker_type.worker_registration_fn();
     parse_quote_spanned!(worker_name.span()=>
         #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
         #[allow(non_snake_case)]
-        pub fn #func_name() -> ::leptos_workers::workers::#worker_fn_type {
-            ::leptos_workers::workers::#worker_fn_type::new::<#worker_name>()
+        pub fn #func_name() {
+            ::leptos_workers::workers::#worker_registration_fn::<#worker_name>();
         }
     )
 }
@@ -426,6 +426,7 @@ mod tests {
     use syn::parse_quote;
 
     #[allow(dead_code)]
+    #[track_caller]
     fn assert_eq_quoted<L: ToTokens + PartialEq<R>, R: ToTokens>(lhs: &L, rhs: &R) {
         if lhs != rhs {
             assert_eq!(
@@ -670,8 +671,8 @@ mod tests {
         let expected: ItemFn = parse_quote!(
             #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
             #[allow(non_snake_case)]
-            pub fn WORKERS_FUTURE_TestFutureWorker() -> ::leptos_workers::workers::FutureWorkerFn {
-                ::leptos_workers::workers::FutureWorkerFn::new::<TestFutureWorker>()
+            pub fn WORKERS_FUTURE_TestFutureWorker() {
+                ::leptos_workers::workers::register_future_worker::<TestFutureWorker>();
             }
         );
         assert_eq_quoted(&expected, &ir.wasm_bindgen_func);

--- a/leptos_workers_macro/src/v2/lower.rs
+++ b/leptos_workers_macro/src/v2/lower.rs
@@ -485,8 +485,8 @@ mod tests {
         let expected: ItemFn = parse_quote!(
             #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
             #[allow(non_snake_case)]
-            pub fn WORKERS_FUTURE_TestFutureWorker() -> ::leptos_workers::workers::FutureWorkerFn {
-                ::leptos_workers::workers::FutureWorkerFn::new::<TestFutureWorker>()
+            pub fn WORKERS_FUTURE_TestFutureWorker() {
+                ::leptos_workers::workers::register_future_worker::<TestFutureWorker>();
             }
         );
         assert_eq_quoted(&expected, &ir.wasm_bindgen_func);
@@ -578,8 +578,8 @@ mod tests {
         let expected: ItemFn = parse_quote!(
             #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
             #[allow(non_snake_case)]
-            pub fn WORKERS_FUTURE_TestFutureWorker() -> ::leptos_workers::workers::FutureWorkerFn {
-                ::leptos_workers::workers::FutureWorkerFn::new::<TestFutureWorker>()
+            pub fn WORKERS_FUTURE_TestFutureWorker() {
+                ::leptos_workers::workers::register_future_worker::<TestFutureWorker>();
             }
         );
         assert_eq_quoted(&expected, &ir.wasm_bindgen_func);

--- a/leptos_workers_macro/src/v2/lower.rs
+++ b/leptos_workers_macro/src/v2/lower.rs
@@ -101,7 +101,7 @@ fn lower_wasm_bindgen_func(model: &Model) -> ItemFn {
     let func_name = format_ident!("{prefix}_{worker_name}");
     let worker_fn_type = worker_type.worker_fn_type();
     parse_quote_spanned!(worker_name.span()=>
-        #[::leptos_workers::wasm_bindgen]
+        #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
         #[allow(non_snake_case)]
         pub fn #func_name() -> ::leptos_workers::workers::#worker_fn_type {
             ::leptos_workers::workers::#worker_fn_type::new::<#worker_name>()
@@ -482,7 +482,7 @@ mod tests {
         assert_eq_quoted(&expected, &ir.impl_web_worker_path);
 
         let expected: ItemFn = parse_quote!(
-            #[::leptos_workers::wasm_bindgen]
+            #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
             #[allow(non_snake_case)]
             pub fn WORKERS_FUTURE_TestFutureWorker() -> ::leptos_workers::workers::FutureWorkerFn {
                 ::leptos_workers::workers::FutureWorkerFn::new::<TestFutureWorker>()
@@ -575,7 +575,7 @@ mod tests {
         assert_eq_quoted(&expected, &ir.impl_web_worker_path);
 
         let expected: ItemFn = parse_quote!(
-            #[::leptos_workers::wasm_bindgen]
+            #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
             #[allow(non_snake_case)]
             pub fn WORKERS_FUTURE_TestFutureWorker() -> ::leptos_workers::workers::FutureWorkerFn {
                 ::leptos_workers::workers::FutureWorkerFn::new::<TestFutureWorker>()
@@ -668,7 +668,7 @@ mod tests {
         assert_eq_quoted(&expected, &ir.impl_web_worker_path);
 
         let expected: ItemFn = parse_quote!(
-            #[::leptos_workers::wasm_bindgen]
+            #[::leptos_workers::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos_workers::wasm_bindgen)]
             #[allow(non_snake_case)]
             pub fn WORKERS_FUTURE_TestFutureWorker() -> ::leptos_workers::workers::FutureWorkerFn {
                 ::leptos_workers::workers::FutureWorkerFn::new::<TestFutureWorker>()


### PR DESCRIPTION
Contains some of the changes I had to make to hack in a worker that is able to accept more than one type of work item later on. Quick explanation of some stuff:

The worker that is currently spawned handles only one `W: *Worker`, hence I have decided to call this ~~"dedicated worker"~~ "unifunctional worker".

The current implementation allows structs to implement multiple worker types and the unifunctional worker accepts all these implemented "call modes". It's not clear if this is intended, since the macro will generate a new struct and implement exactly one `*Worker` type. It shouldn't hurt to allow this, removing this would, I think, get rid of having to send the `WorkerMsgType` to dedicated workers.

The generated externally-visible methods now register themselves when called instead of returning a struct that merely round-trips through wasm/js/wasm into the `register_*` methods. I use these to auto-detect which worker should handle a message in my general worker, props to the thought. The idea would be to detect on which type of worker the registration method is called in (if any) via some global flag that gets set in the worker module and register accordingly internally (or ignore any calls on the main page).